### PR TITLE
Fix for Django 1.8 [#91655046]

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -382,7 +382,8 @@ def _foreign_key_ignoring_handle(self, *fixture_labels, **options):
             connection.close()
 
 
-def _skip_create_test_db(self, verbosity=1, autoclobber=False, serialize=True):
+def _skip_create_test_db(self, verbosity=1, autoclobber=False, serialize=True,
+                         keepdb=True):
     """``create_test_db`` implementation that skips both creation and flushing
 
     The idea is to re-use the perfectly good test DB already created by an
@@ -430,7 +431,6 @@ def _should_create_database(connection):
     # hits the DB for no good reason. Until we find a faster way, I'm inclined
     # to keep making people explicitly saying REUSE_DB if they want to reuse
     # the DB.
-
     if not _can_support_reuse_db(connection):
         return True
 
@@ -513,14 +513,15 @@ class NoseTestSuiteRunner(BasicNoseRunner):
                     reset_statements = connection.ops.sequence_reset_sql(
                             style, self._get_models_for_connection(connection))
 
-                for reset_statement in reset_statements:
-                    cursor.execute(reset_statement)
-
-                # Django v1.3 (https://code.djangoproject.com/ticket/9964)
-                # starts using commit_unless_managed() for individual
-                # connections. Backwards compatibility for Django 1.2 is to use
-                # the generic transaction function.
-                transaction.commit_unless_managed(using=connection.alias)
+                if hasattr(transaction, "atomic"):
+                    with transaction.atomic(using=connection.alias):
+                        for reset_statement in reset_statements:
+                            cursor.execute(reset_statement)
+                else:
+                    # Django < 1.6
+                    for reset_statement in reset_statements:
+                        cursor.execute(reset_statement)
+                    transaction.commit_unless_managed(using=connection.alias)
 
                 # Each connection has its own creation object, so this affects
                 # only a single connection:


### PR DESCRIPTION
Fix for Django 1.8 to avoid using legacy transaction management methods (`django-nose` [issue #197](https://github.com/django-nose/django-nose/issues/197))

This patch was taken from rejected [PR 207](https://github.com/django-nose/django-nose/pull/207)
